### PR TITLE
Remove version locks

### DIFF
--- a/activeresource-response.gemspec
+++ b/activeresource-response.gemspec
@@ -13,10 +13,10 @@ Gem::Specification.new do |s|
   s.description = %q{This gem adds possibility to access http response object from result of ActiveResource::Base find method }
   s.license     = 'MIT'
 
-  s.add_runtime_dependency('activeresource', ['>= 3', '< 6.1'])
+  s.add_runtime_dependency('activeresource', ['>= 3'])
   s.add_dependency "jruby-openssl" if RUBY_PLATFORM == "java"
   s.add_development_dependency "minitest" , '~> 5.3'
-  s.add_development_dependency 'rake', '~> 10'
+  s.add_development_dependency 'rake', '~> 13'
   s.add_development_dependency 'byebug'
 
 

--- a/activeresource-response.gemspec
+++ b/activeresource-response.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('activeresource', ['>= 3'])
   s.add_dependency "jruby-openssl" if RUBY_PLATFORM == "java"
   s.add_development_dependency "minitest" , '~> 5.3'
-  s.add_development_dependency 'rake', '~> 13'
+  s.add_development_dependency 'rake', '>= 10.0'
   s.add_development_dependency 'byebug'
 
 

--- a/lib/active_resource_response/version.rb
+++ b/lib/active_resource_response/version.rb
@@ -23,6 +23,6 @@
 
 module ActiveResourceResponse
   module Version
-    VERSION = "1.4.0"
+    VERSION = "1.5.0"
   end
 end


### PR DESCRIPTION
This PR satisfies:
[Fork the `activeresource-response` gem](https://adjustcom.atlassian.net/browse/ADAPP-17642)

Notes:
- @fixme did all the work, but since he is busy, I will write the PR for him;
- Remove the upper version lock for `activeresource`. Having an upper version lock is a common pattern in gems, but since the author of this one appears to have moved on, we fork it and remove this limit. Sergei checked, and there seems to be no issue;
- While he was at it, Sergei also decided to update `rake`, because version 10 has already given him grief.